### PR TITLE
Include the LICENSE and README in the source distribution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 pyformance.egg-info
 .idea
+/.tox/
+/build/
+/dist/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include README.md


### PR DESCRIPTION
This makes it even more explicit what license this project is under.

Along with this, it also filters out some build directories.