### PR TITLE
TestCsvReporter: avoid interference via TimedTestCase.clock

### DIFF
--- a/tests/test__csv_reporter.py
+++ b/tests/test__csv_reporter.py
@@ -9,13 +9,14 @@ else:
 
 from pyformance import MetricsRegistry
 from pyformance.reporters.csv_reporter import CsvReporter
-from tests import TimedTestCase
+from tests import ManualClock, TimedTestCase
 
 
 class TestCsvReporter(TimedTestCase):
 
     def setUp(self):
         super(TestCsvReporter, self).setUp()
+        self.clock = ManualClock()
         self.path = tempfile.mktemp()
         self.registry = MetricsRegistry(clock=self.clock)
         self.maxDiff = None


### PR DESCRIPTION
This fixes random failures which can occur when running all unit
tests in a single python invocation. The timestamp in the
test_report_now method will not match unless self.clock.now is
0, so it's unsafe to use the global TimedTestCase.clock instance
for this test.