### PR TITLE
Support sliding time windows in addition to exponentially-decaying samples

### DIFF
--- a/pyformance/meters/histogram.py
+++ b/pyformance/meters/histogram.py
@@ -10,20 +10,23 @@ class Histogram(object):
     A metric which calculates the distribution of a value.
     """
 
-    def __init__(self, size=DEFAULT_SIZE, alpha=DEFAULT_ALPHA, clock=time):
+    def __init__(self, size=DEFAULT_SIZE, alpha=DEFAULT_ALPHA, clock=time,
+                 sample=None):
         """
         Creates a new instance of a L{Histogram}.
         """
         super(Histogram, self).__init__()
         self.lock = Lock()
         self.clock = clock
-        self.sample = ExpDecayingSample(size, alpha, clock)
+        if sample is None:
+            sample = ExpDecayingSample(size, alpha, clock)
+        self.sample = sample
         self.clear()
 
     def add(self, value):
         """
         Add value to histogram
-        
+
         :type value: float
         """
         with self.lock:

--- a/pyformance/meters/timer.py
+++ b/pyformance/meters/timer.py
@@ -18,13 +18,14 @@ class Timer(object):
     """
     A timer metric which aggregates timing durations and provides duration statistics, plus
     throughput statistics via Meter and Histogram.
-      
+
     """
 
-    def __init__(self, threshold=None, size=DEFAULT_SIZE, alpha=DEFAULT_ALPHA, clock=time, sink=None):
+    def __init__(self, threshold=None, size=DEFAULT_SIZE, alpha=DEFAULT_ALPHA,
+                 clock=time, sink=None, sample=None):
         super(Timer, self).__init__()
         self.meter = Meter(clock=clock)
-        self.hist = Histogram(size=size, alpha=alpha, clock=clock)
+        self.hist = Histogram(size=size, alpha=alpha, clock=clock, sample=sample)
         self.sink = sink
         self.threshold = threshold
 

--- a/pyformance/stats/samples.py
+++ b/pyformance/stats/samples.py
@@ -110,3 +110,38 @@ class ExpDecayingSample(object):
 
     def get_snapshot(self):
         return Snapshot(self.values.values())
+
+
+class SlidingTimeWindowSample(object):
+
+    """
+    A sample of measurements made in a sliding time window.
+    """
+
+    DEFAULT_WINDOW = 300
+
+    def __init__(self, window=DEFAULT_WINDOW, clock=time):
+        """Creates a SlidingTimeWindowSample.
+
+        :param window: the length of the time window in seconds
+        :param clock: clock.time() is called to get the current time as seconds
+                      since the epoch.
+        """
+        self.window = window
+        self.clock = clock
+        self.clear()
+
+    def clear(self):
+        self.values = []
+
+    def _trim(self):
+        deadline = self.clock.time() - self.window
+        while self.values and self.values[0][0] < deadline:
+            heapq.heappop(self.values)
+
+    def update(self, value):
+        heapq.heappush(self.values, (self.clock.time(), value))
+
+    def get_snapshot(self):
+        self._trim()
+        return Snapshot(x[1] for x in self.values)

--- a/tests/test__histogram.py
+++ b/tests/test__histogram.py
@@ -41,7 +41,7 @@ class HistogramTestCase(TimedTestCase):
         self.assertAlmostEqual(9.1666, hist.get_var(), delta=0.0001)
 
     def test__a_long_wait_should_not_corrupt_sample(self):
-        hist = Histogram(10, 0.015, self.clock)
+        hist = Histogram(10, 0.015, clock=self.clock)
 
         for i in range(1000):
             hist.add(1000 + i)


### PR DESCRIPTION
Exponentially-decaying reservoir is not always the right thing. This patch implements a sliding time window sample as an alternative.