### PR TITLE
Autocreate Influx database on metrics push

### DIFF
--- a/pyformance/reporters/influx.py
+++ b/pyformance/reporters/influx.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import urllib2
 import base64
+import logging
 
 from .reporter import Reporter
+
+LOG = logging.getLogger(__name__)
 
 DEFAULT_INFLUX_SERVER = '127.0.0.1'
 DEFAULT_INFLUX_PORT = 8086
@@ -16,7 +19,7 @@ class InfluxReporter(Reporter):
 
     """
     InfluxDB reporter using native http api
-    (based on https://influxdb.com/docs/v0.9/guides/writing_data.html)
+    (based on https://influxdb.com/docs/v1.1/guides/writing_data.html)
     """
 
     def __init__(self, registry=None, reporting_interval=5, prefix="",
@@ -24,7 +27,7 @@ class InfluxReporter(Reporter):
                  username=DEFAULT_INFLUX_USERNAME,
                  password=DEFAULT_INFLUX_PASSWORD,
                  port=DEFAULT_INFLUX_PORT, protocol=DEFAULT_INFLUX_PROTOCOL,
-                 clock=None):
+                 autocreate_database=False, clock=None):
         super(InfluxReporter, self).__init__(
             registry, reporting_interval, clock)
         self.prefix = prefix
@@ -34,8 +37,31 @@ class InfluxReporter(Reporter):
         self.port = port
         self.protocol = protocol
         self.server = server
+        self.autocreate_database = autocreate_database
+        self._did_create_database = False
+
+
+    def _create_database(self):
+        url = "%s://%s:%s/query" % (self.protocol, self.server, self.port)
+        q = urllib2.quote("CREATE DATABASE %s" % self.database)
+        request = urllib2.Request(url + "?q=" + q)
+        if self.username:
+            auth = base64.encodestring(
+                '%s:%s' % (self.username, self.password))[:-1]
+            request.add_header("Authorization", "Basic %s" % auth)
+        try:
+            response = urllib2.urlopen(request)
+            _result = response.read()
+            # Only set if we actually were able to get a successful response
+            self._did_create_database = True
+        except urllib2.URLError, err:
+            LOG.warning("Cannot create database %s to %s: %s" %
+                               (self.database, self.server, err.reason))
+
 
     def report_now(self, registry=None, timestamp=None):
+        if self.autocreate_database and not self._did_create_database:
+            self._create_database()
         timestamp = timestamp or int(round(self.clock.time()))
         metrics = (registry or self.registry).dump_metrics()
         post_data = []
@@ -58,10 +84,7 @@ class InfluxReporter(Reporter):
             request.add_header("Authorization", "Basic %s" % auth)
         try:
             response = urllib2.urlopen(request)
+            _result = response.read()
         except urllib2.URLError, err:
-            if err.code == 404:
-                raise RuntimeError("Cannot write to %s: Database %r not found. %s" %
-                                   (self.server, self.database, err.reason))
-            raise RuntimeError("Cannot write to %s: %s %s" %
-                               (self.server, err.code, err.reason))
-        _result = response.read()
+            LOG.warning("Cannot write to %s: %s" %
+                               (self.server, err.reason))


### PR DESCRIPTION
This is a small feature addition that will autocreate the InfluxDB database used by the registry instance the first time metrics are pushed. The database is constructed per the registry configuration (server, port, protocol, database name, etc.).

If database creation fails the first time, it will be retried until a successful HTTP response comes back.

This feature should be safe for multiple use, as [trying to create a pre-existing database has no net side effects](https://github.com/influxdata/influxdb/blob/f05df2a263e36b6cf783c45a1a6a2a7e0e82b468/services/meta/client.go#L177-L207) on InfluxDB itself.

Lastly, this change makes the reporter continue even with failures, by logging out warnings rather than throwing `RuntimeError`s and crashing the program.