### PR TITLE
Add __enter__ and __exit__ to CsvReporter

### DIFF
--- a/pyformance/reporters/csv_reporter.py
+++ b/pyformance/reporters/csv_reporter.py
@@ -47,3 +47,11 @@ class CsvReporter(Reporter):
                 cols.append(values[vk])
             f.write("%s\n" % self.separator.join(map(str, cols)))
             f.flush()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        for f in self.files.values():
+            f.close()
+

--- a/tests/test__csv_reporter.py
+++ b/tests/test__csv_reporter.py
@@ -29,10 +29,12 @@ class TestCsvReporter(TimedTestCase):
     def test_report_now(self):
         g1 = self.registry.gauge("gauge1")
         g1.set_value(123)
-        r = CsvReporter(
+
+        with CsvReporter(
             registry=self.registry, reporting_interval=1, clock=self.clock,
-            path=self.path)
-        r.report_now()
+            path=self.path) as r:
+            r.report_now()
+
         output_filename = os.path.join(self.path, "gauge1.csv")
 
         output = open(output_filename).read()


### PR DESCRIPTION
This change allows closing the file handlers after using the CsvReporter, e.g. by using 'with CsvReporter() as r:'.

This fixes https://github.com/omergertel/pyformance/issues/37 