### PR TITLE
Fix InfluxDB reporter for Python 3

### DIFF
--- a/pyformance/reporters/influx.py
+++ b/pyformance/reporters/influx.py
@@ -69,19 +69,19 @@ class InfluxReporter(Reporter):
         timestamp = timestamp or int(round(self.clock.time()))
         metrics = (registry or self.registry).dump_metrics()
         post_data = []
-        for key, metric_values in metrics.iteritems():
+        for key, metric_values in metrics.items():
             if not self.prefix:
                 table = key
             else:
                 table = "%s.%s" % (self.prefix, key)
             values = ",".join(["%s=%s" % (k, v)
-                              for (k, v) in metric_values.iteritems()])
+                              for (k, v) in metric_values.items()])
             line = "%s %s %s" % (table, values, timestamp)
             post_data.append(line)
         post_data = "\n".join(post_data)
         path = "/write?db=%s&precision=s" % self.database
         url = "%s://%s:%s%s" % (self.protocol, self.server, self.port, path)
-        request = Request(url, post_data)
+        request = Request(url, post_data.encode("utf-8"))
         if self.username:
             auth = base64.encodestring(
                 '%s:%s' % (self.username, self.password))[:-1]

--- a/tests/test__influx_reporter.py
+++ b/tests/test__influx_reporter.py
@@ -1,5 +1,34 @@
-from pyformance.reporters import influx  # just a syntax/sanity check
+import os
+import mock
 
+try:
+    from urllib2 import Request
+except ImportError:
+    from urllib.request import Request
 
-def test_initializes():
-    influx.InfluxReporter()
+from pyformance.reporters.influx import InfluxReporter
+from pyformance import MetricsRegistry
+from tests import TimedTestCase
+
+class TestInfluxReporter(TimedTestCase):
+    def setUp(self):
+        super(TestInfluxReporter, self).setUp()
+        self.registry = MetricsRegistry()
+
+    def tearDown(self):
+        super(TestInfluxReporter, self).tearDown()
+
+    def test_report_now(self):
+        influx_reporter = InfluxReporter(registry=self.registry)
+
+        with mock.patch("pyformance.reporters.influx.urlopen") as patch:
+            influx_reporter.report_now()
+            patch.assert_called()
+
+    def test_create_database(self):
+        r1 = InfluxReporter(registry=self.registry, autocreate_database=True)
+        with mock.patch("pyformance.reporters.influx.urlopen") as patch:
+            r1.report_now()
+            if patch.call_count != 2:
+                raise AssertionError(
+                    "Expected 2 calls to 'urlopen'. Received: {}".format(patch.call_count))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35
+envlist = py27,py34,py35,py36
 
 [testenv]
 commands=


### PR DESCRIPTION
Due to the removal of the `dict.iteritems()` method and changes to urllib, the InfluxDB reporter was not functional in Python 3. The following changes have been made to fix this:

-  The `dict.iteritems()` call has been replaced by `dict.items()` which is compatible with both Python 2 and Python 3.

- urllib expects data as an array of bytes rather than as a string in Python 3, which was causing a `TypeError`. Data will now be encoded to utf-8 which will work for both Python 2 and Python 3.

- Replaced the syntax/sanity check with more thorough tests

- Added the most recent version of Python to the tox envlist