### PR TITLE
Set pickle protocol to 2 in CarbonReporter to make it work with Python3

### DIFF
--- a/pyformance/reporters/carbon_reporter.py
+++ b/pyformance/reporters/carbon_reporter.py
@@ -40,11 +40,14 @@ class CarbonReporter(Reporter):
         timestamp = timestamp or int(round(self.clock.time()))
         metrics = registry.dump_metrics()
         if self.pickle_protocol:
-            payload = pickle.dumps([
-                ("%s%s.%s" % (self.prefix, metric_name, metic_key), (timestamp, metric_value))
-                for metric_name, metric in iteritems(metrics)
-                for metic_key, metric_value in iteritems(metric)
-            ])
+            payload = pickle.dumps(
+                [
+                    ("%s%s.%s" % (self.prefix, metric_name, metic_key), (timestamp, metric_value))
+                    for metric_name, metric in iteritems(metrics)
+                    for metic_key, metric_value in iteritems(metric)
+                ],
+                protocol=2
+            )
             header = struct.pack("!L", len(payload))
             return header + payload
         else:


### PR DESCRIPTION
I found that when running in Python 3, metrics were not being collected by Carbon although I could see them being sent. I think that Carbon is normally run using Python 2, so setting the pickle protocol version to this appears to fix the issue.