### PR TITLE
Get min, max, mean, stddev histogram statistics from snapshot of histogram, rather than entire histogram

### DIFF
--- a/pyformance/meters/timer.py
+++ b/pyformance/meters/timer.py
@@ -34,28 +34,28 @@ class Timer(object):
         return self.hist.get_count()
 
     def get_sum(self):
-        "get sum from internal histogram"
-        return self.hist.get_sum()
+        "get sum from snapshot of internal histogram"
+        return self.get_snapshot().get_sum()
 
     def get_max(self):
-        "get max from internal histogram"
-        return self.hist.get_max()
+        "get max from snapshot of internal histogram"
+        return self.get_snapshot().get_max()
 
     def get_min(self):
-        "get min from internal histogram"
-        return self.hist.get_min()
+        "get min from snapshot of internal histogram"
+        return self.get_snapshot().get_min()
 
     def get_mean(self):
-        "get mean from internal histogram"
-        return self.hist.get_mean()
+        "get mean from snapshot of internal histogram"
+        return self.get_snapshot().get_mean()
 
     def get_stddev(self):
-        "get stddev from internal histogram"
-        return self.hist.get_stddev()
+        "get stddev from snapshot of internal histogram"
+        return self.get_snapshot().get_stddev()
 
     def get_var(self):
-        "get var from internal histogram"
-        return self.hist.get_var()
+        "get var from snapshot of internal histogram"
+        return self.get_snapshot().get_var()
 
     def get_snapshot(self):
         "get snapshot from internal histogram"

--- a/pyformance/registry.py
+++ b/pyformance/registry.py
@@ -139,11 +139,11 @@ class MetricsRegistry(object):
         if key in self._histograms:
             histogram = self._histograms[key]
             snapshot = histogram.get_snapshot()
-            res = {"avg": histogram.get_mean(),
+            res = {"avg": snapshot.get_mean(),
                    "count": histogram.get_count(),
-                   "max": histogram.get_max(),
-                   "min": histogram.get_min(),
-                   "std_dev": histogram.get_stddev(),
+                   "max": snapshot.get_max(),
+                   "min": snapshot.get_min(),
+                   "std_dev": snapshot.get_stddev(),
                    "75_percentile": snapshot.get_75th_percentile(),
                    "95_percentile": snapshot.get_95th_percentile(),
                    "99_percentile": snapshot.get_99th_percentile(),

--- a/pyformance/stats/snapshot.py
+++ b/pyformance/stats/snapshot.py
@@ -1,3 +1,6 @@
+import math
+
+
 class Snapshot(object):
 
     """
@@ -17,6 +20,42 @@ class Snapshot(object):
     def get_size(self):
         "get current size"
         return len(self.values)
+
+    def get_sum(self):
+        "get current sum"
+        return float(sum(self.values))
+
+    def get_max(self):
+        "get current maximum value"
+        if not self.values:
+            return 0
+        return self.values[-1]
+
+    def get_min(self):
+        "get current minimum value"
+        if not self.values:
+            return 0
+        return self.values[0]
+
+    def get_mean(self):
+        "get current mean value"
+        if not self.values:
+            return 0
+        return float(sum(self.values)) / self.get_size()
+
+    def get_stddev(self):
+        "get current standard deviation"
+        if not self.values:
+            return 0
+        return math.sqrt(self.get_var())
+
+    def get_var(self):
+        "get current variance"
+        if not self.values or self.get_size() == 1:
+            return 0
+        mean = self.get_mean()
+        square_differences = [(mean - value) ** 2 for value in self.values]
+        return sum(square_differences) / (self.get_size() - 1)
 
     def get_median(self):
         "get current median"

--- a/tests/test__carbon_reporter.py
+++ b/tests/test__carbon_reporter.py
@@ -78,7 +78,7 @@ class TestCarbonReporter(TimedTestCase):
             'hist.min 1 2',
             'hist.95_percentile 512 2',
             'hist.75_percentile 160.0 2',
-            'hist.std_dev 164.94851048466947 2' \
+            'hist.std_dev 164.94851048466944 2' \
                 if PY3 else 'hist.std_dev 164.948510485 2',
             'hist.max 512 2',
             'hist.avg 102.3 2',
@@ -123,7 +123,7 @@ class TestCarbonReporter(TimedTestCase):
             ('hist.min', (2, 1)),
             ('hist.95_percentile', (2, 512.0)),
             ('hist.75_percentile', (2, 160.0)),
-            ('hist.std_dev', (2, 164.94851048466947)),
+            ('hist.std_dev', (2, 164.94851048466944)),
             ('hist.max', (2, 512.0)),
             ('hist.avg', (2, 102.3)),
             ('m1.count', (2, 1)),

--- a/tests/test__console_reporter.py
+++ b/tests/test__console_reporter.py
@@ -65,7 +65,7 @@ class TestConsoleReporter(TimedTestCase):
                          '                 min = 1',
                          '       95_percentile = 512',
                          '       75_percentile = 160.0',
-                         '             std_dev = 164.948510485',
+                         '             std_dev = 164.94851048466944',
                          '                 max = 512',
                          '                 avg = 102.3',
                          'm1:', '               count = 1.0',

--- a/tests/test__syslog_reporter.py
+++ b/tests/test__syslog_reporter.py
@@ -19,7 +19,7 @@ class TestSysLogReporter(TimedTestCase):
         self.clock.now = 0
 
     def test_report_now(self):
-        #connect to a logal rsyslog server
+        # connect to a local rsyslog server
         r = SysLogReporter(registry=self.registry, reporting_interval=1, clock=self.clock)
         h1 = self.registry.histogram("hist")
         for i in range(10):
@@ -38,7 +38,7 @@ class TestSysLogReporter(TimedTestCase):
             self.clock.add(1)
         with mock.patch("pyformance.reporters.syslog_reporter.logging.Logger.info") as patch:
             r.report_now()
-            expected = '{"c1.count": 1, "counter-2.count": -2, "gcb.value": 123, "gsimple.value": 42, "hist.75_percentile": 160.0, "hist.95_percentile": 512, "hist.999_percentile": 512, "hist.99_percentile": 512, "hist.avg": 102.3, "hist.count": 10.0, "hist.max": 512, "hist.min": 1, "hist.std_dev": 164.94851048466947, "m1.15m_rate": 0, "m1.1m_rate": 0, "m1.5m_rate": 0, "m1.count": 1.0, "m1.mean_rate": 1.0, "t1.15m_rate": 0, "t1.1m_rate": 0, "t1.50_percentile": 1, "t1.5m_rate": 0, "t1.75_percentile": 1, "t1.95_percentile": 1, "t1.999_percentile": 1, "t1.99_percentile": 1, "t1.avg": 1.0, "t1.count": 1.0, "t1.max": 1, "t1.mean_rate": 1.0, "t1.min": 1, "t1.std_dev": 0.0, "t1.sum": 1.0, "timestamp": 1}'
+            expected = '{"c1.count": 1, "counter-2.count": -2, "gcb.value": 123, "gsimple.value": 42, "hist.75_percentile": 160.0, "hist.95_percentile": 512, "hist.999_percentile": 512, "hist.99_percentile": 512, "hist.avg": 102.3, "hist.count": 10.0, "hist.max": 512, "hist.min": 1, "hist.std_dev": 164.94851048466944, "m1.15m_rate": 0, "m1.1m_rate": 0, "m1.5m_rate": 0, "m1.count": 1.0, "m1.mean_rate": 1.0, "t1.15m_rate": 0, "t1.1m_rate": 0, "t1.50_percentile": 1, "t1.5m_rate": 0, "t1.75_percentile": 1, "t1.95_percentile": 1, "t1.999_percentile": 1, "t1.99_percentile": 1, "t1.avg": 1.0, "t1.count": 1.0, "t1.max": 1, "t1.mean_rate": 1.0, "t1.min": 1, "t1.std_dev": 0.0, "t1.sum": 1.0, "timestamp": 1}'
  
             patch.assert_called_with(expected)
 


### PR DESCRIPTION
This is to more closely match the behaviour of Codahale metrics.

I imagine that the max/min/mean since the last application restart are not that helpful for most people, though I could be wrong in this assumption.

The standard deviation value has changed slightly in the tests. As far as I can tell, the new value is slightly further from the old value (in the other direction, as calculated by Wolfram Alpha), but I don't believe it to be significant.