### PR TITLE
Fix import of hosted_graphite_reporter.py for python >= 3.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -11,3 +11,5 @@ Changed and new in fork
 * pass clock attribute from registry to meters (required for reporter-tests)
 * wrote a simple example script which collects system metrics
 * started documentation based on sphinx
+* fix urllib2 import in hosted_graphite_reporter.py
+* using six.moves to handle import between different py version instead of checking for the current version

--- a/pyformance/reporters/hosted_graphite_reporter.py
+++ b/pyformance/reporters/hosted_graphite_reporter.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 import sys
-import urllib2
 import base64
+
+from six.moves import urllib
 
 from .meters import Counter, Histogram, Meter, Timer
 from .registry import MetricsRegistry
@@ -28,10 +29,10 @@ class HostedGraphiteReporter(Reporter):
         if metrics:
             try:
                 # XXX: better use http-keepalive/pipelining somehow?
-                request = urllib2.Request(self.url, metrics)
+                request = urllib.request.Request(self.url, metrics)
                 request.add_header("Authorization", "Basic %s" %
                                    base64.encodestring(self.api_key).strip())
-                result = urllib2.urlopen(request)
+                result = urllib.request.urlopen(request)
             except Exception as e:
                 print(e, file=sys.stderr)
 

--- a/pyformance/reporters/influx.py
+++ b/pyformance/reporters/influx.py
@@ -2,12 +2,8 @@
 
 import base64
 import logging
-try:
-    from urllib2 import quote, urlopen, Request, URLError
-except ImportError:
-    from urllib.error import URLError
-    from urllib.parse import quote
-    from urllib.request import urlopen, Request
+
+from six.moves import urllib
 
 from .reporter import Reporter
 
@@ -47,17 +43,17 @@ class InfluxReporter(Reporter):
 
     def _create_database(self):
         url = "%s://%s:%s/query" % (self.protocol, self.server, self.port)
-        q = quote("CREATE DATABASE %s" % self.database)
-        request = Request(url + "?q=" + q)
+        q = urllib.parse.quote("CREATE DATABASE %s" % self.database)
+        request = urllib.request.Request(url + "?q=" + q)
         if self.username:
             auth = _encode_username(self.username, self.password)
             request.add_header("Authorization", "Basic %s" % auth.decode('utf-8'))
         try:
-            response = urlopen(request)
+            response = urllib.request.urlopen(request)
             _result = response.read()
             # Only set if we actually were able to get a successful response
             self._did_create_database = True
-        except URLError as err:
+        except urllib.error.URLError as err:
             LOG.warning("Cannot create database %s to %s: %s",
                         self.database, self.server, err.reason)
 
@@ -80,14 +76,14 @@ class InfluxReporter(Reporter):
         post_data = "\n".join(post_data)
         path = "/write?db=%s&precision=s" % self.database
         url = "%s://%s:%s%s" % (self.protocol, self.server, self.port, path)
-        request = Request(url, post_data.encode("utf-8"))
+        request = urllib.request.Request(url, post_data.encode("utf-8"))
         if self.username:
             auth = _encode_username(self.username, self.password)
             request.add_header("Authorization", "Basic %s" % auth.decode('utf-8'))
         try:
-            response = urlopen(request)
+            response = urllib.request.urlopen(request)
             response.read()
-        except URLError as err:
+        except urllib.error.URLError as err:
             LOG.warning("Cannot write to %s: %s",
                         self.server, err.reason)
 

--- a/pyformance/reporters/newrelic_reporter.py
+++ b/pyformance/reporters/newrelic_reporter.py
@@ -4,15 +4,10 @@ import json
 import os
 import socket
 import sys
+
+from six.moves import urllib
+
 from pyformance.registry import set_global_registry, MetricsRegistry
-
-if sys.version_info[0] > 2:
-    import urllib.request as urllib
-    import urllib.error as urlerror
-else:
-    import urllib2 as urllib
-    import urllib2 as urlerror
-
 from pyformance.__version__ import __version__
 
 from .reporter import Reporter
@@ -36,7 +31,6 @@ class NewRelicSink(object):
         self.sum_of_squares += seconds * seconds
         self.min = min(self.min, seconds) if self.min else seconds
         self.max = max(self.max, seconds) if self.max else seconds
-        pass
 
 
 class NewRelicRegistry(MetricsRegistry):
@@ -72,11 +66,11 @@ class NewRelicReporter(Reporter):
         if metrics:
             try:
                 # XXX: better use http-keepalive/pipelining somehow?
-                request = urllib.Request(self.PLATFORM_URL, metrics.encode() if sys.version_info[0] > 2 else metrics)
+                request = urllib.request.Request(self.PLATFORM_URL, metrics.encode() if sys.version_info[0] > 2 else metrics)
                 for k, v in self.http_headers.items():
                     request.add_header(k, v)
-                result = urllib.urlopen(request)
-                if isinstance(result, urlerror.HTTPError):
+                result = urllib.request.urlopen(request)
+                if isinstance(result, urllib.error.HTTPError):
                     raise result
             except Exception as e:
                 print(e, file=sys.stderr)

--- a/pyformance/reporters/opentsdb_reporter.py
+++ b/pyformance/reporters/opentsdb_reporter.py
@@ -5,12 +5,7 @@ from .reporter import Reporter
 import base64
 import json
 
-if sys.version_info[0] > 2:
-    import urllib.request as urllib
-    import urllib.error as urlerror
-else:
-    import urllib2 as urllib
-    import urllib2 as urlerror
+from six.moves import urllib
 
 
 class OpenTSDBReporter(Reporter):
@@ -33,13 +28,13 @@ class OpenTSDBReporter(Reporter):
         metrics = self._collect_metrics(registry or self.registry, timestamp)
         if metrics:
             try:
-                request = urllib.Request(self.url,
+                request = urllib.request.Request(self.url,
                                          data=json.dumps(metrics).encode("utf-8"),
                                          headers={'content-type': "application/json"})
                 authentication_data = "{0}:{1}".format(self.application_name, self.write_key)
                 auth_header = base64.b64encode(bytes(authentication_data.encode("utf-8")))
                 request.add_header("Authorization", "Basic {0}".format(auth_header))
-                urllib.urlopen(request)
+                urllib.request.urlopen(request)
             except Exception as e:
                 sys.stderr.write("{0}\n".format(e))
 

--- a/tests/test__console_reporter.py
+++ b/tests/test__console_reporter.py
@@ -1,8 +1,4 @@
-import sys
-if sys.version_info[0] < 3:
-    from StringIO import StringIO
-else:
-    from io import StringIO
+from six.moves import StringIO
 
 from pyformance import MetricsRegistry
 from pyformance.reporters.console_reporter import ConsoleReporter

--- a/tests/test__csv_reporter.py
+++ b/tests/test__csv_reporter.py
@@ -2,10 +2,8 @@ import sys
 import os
 import shutil
 import tempfile
-if sys.version_info[0] < 3:
-    from StringIO import StringIO
-else:
-    from io import StringIO
+
+from six.moves import StringIO
 
 from pyformance import MetricsRegistry
 from pyformance.reporters.csv_reporter import CsvReporter

--- a/tests/test__influx_reporter.py
+++ b/tests/test__influx_reporter.py
@@ -1,10 +1,7 @@
 import os
 import mock
 
-try:
-    from urllib2 import Request
-except ImportError:
-    from urllib.request import Request
+from six.moves.urllib.request import Request
 
 from pyformance.reporters.influx import InfluxReporter
 from pyformance import MetricsRegistry

--- a/tests/test__influx_reporter.py
+++ b/tests/test__influx_reporter.py
@@ -18,13 +18,13 @@ class TestInfluxReporter(TimedTestCase):
     def test_report_now(self):
         influx_reporter = InfluxReporter(registry=self.registry)
 
-        with mock.patch("pyformance.reporters.influx.urlopen") as patch:
+        with mock.patch("pyformance.reporters.influx.urllib.request.urlopen") as patch:
             influx_reporter.report_now()
             patch.assert_called()
 
     def test_create_database(self):
         r1 = InfluxReporter(registry=self.registry, autocreate_database=True)
-        with mock.patch("pyformance.reporters.influx.urlopen") as patch:
+        with mock.patch("pyformance.reporters.influx.urllib.request.urlopen") as patch:
             r1.report_now()
             if patch.call_count != 2:
                 raise AssertionError(

--- a/tests/test__opentsdb_reporter.py
+++ b/tests/test__opentsdb_reporter.py
@@ -53,6 +53,6 @@ class TestOpenTSDBReporter(TimedTestCase):
             c2.dec()
             c2.dec()
             self.clock.add(1)
-        with mock.patch("pyformance.reporters.opentsdb_reporter.urllib.urlopen") as patch:
+        with mock.patch("pyformance.reporters.opentsdb_reporter.urllib.request.urlopen") as patch:
             r.report_now()
             patch.assert_called()


### PR DESCRIPTION
This PR fix an `ImportError` for hosted_graphite_reporter.py wiht python >= 3.5:

`>>> import pyformance.reporters.hosted_graphite_reporter`
`
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/yfaris/dev/opcdaproxy/.env3/lib/python3.5/site-packages/pyformance/reporters/hosted_graphite_reporter.py", line 4, in <module>
    import urllib2
ImportError: No module named 'urllib2'
`

This PR also change the method used to handle different import between different python version with a simpler one using the `six.moves` module.