### PR TITLE
Less cpu load on Python 3 in reporter loop thread

### DIFF
--- a/pyformance/reporters/reporter.py
+++ b/pyformance/reporters/reporter.py
@@ -1,5 +1,6 @@
 import time
 from threading import Thread, Event
+import six
 from ..registry import global_registry, get_qualname
 
 
@@ -43,7 +44,13 @@ class Reporter(object):
             except:
                 pass
             next_loop_time += self.reporting_interval
-            time.sleep(max(0, next_loop_time - time.time()))
+            wait = max(0, next_loop_time - time.time())
+            if six.PY2:
+                time.sleep(wait)
+            elif self._stopped.wait(timeout=wait):
+                # wait is faster/better in Python 3
+                # See http://stackoverflow.com/questions/29082268/python-time-sleep-vs-event-wait
+                break  # true if timeout
         # self._stopped.clear()
 
     def report_now(self, registry=None, timestamp=None):


### PR DESCRIPTION
This is a minor improvement.
Event.wait is better than time.sleep:

See the following page for details:
https://stackoverflow.com/questions/29082268/python-time-sleep-vs-event-wait