### PR TITLE
moved next_loop_time variable to inside the while loop

### DIFF
--- a/pyformance/reporters/reporter.py
+++ b/pyformance/reporters/reporter.py
@@ -39,8 +39,8 @@ class Reporter(object):
         self._stopped.set()
 
     def _loop(self):
-        next_loop_time = time.time()
         while not self._stopped.is_set():
+            next_loop_time = time.time()
             try:
                 self.report_now(self.registry)
             except:


### PR DESCRIPTION
Assume we started the reporter, and then system went to sleep mode. Now when the system starts again the reporter will start continuously, until it catches up to the current time.