### PR TITLE
Log exceptions that happen when reporting metrics

### DIFF
--- a/pyformance/reporters/reporter.py
+++ b/pyformance/reporters/reporter.py
@@ -1,8 +1,11 @@
+import logging
 import time
 from threading import Thread, Event
 import six
 from ..registry import global_registry, get_qualname
 
+
+LOG = logging.getLogger(__name__)
 
 class Reporter(object):
     def create_thread(self):
@@ -43,7 +46,8 @@ class Reporter(object):
         while not self._stopped.is_set():
             try:
                 self.report_now(self.registry)
-            except:
+            except Exception as e:
+                LOG.error("Exception caught while reporting metrics", exc_info=e)
                 pass
             next_loop_time += self.reporting_interval
             wait = max(0, next_loop_time - time.time())


### PR DESCRIPTION
At the moment, if an exception happens inside report_now, it is wholly ignored This means that if there is a fault in the reporter, it may silently sit there, not reporting anything, without anyone's knowledge.

Add some basic logging of caught exceptions so that they show up in user's logs and so that they are able to inspect problems when they arise.