### PR TITLE
Update to remove `pkg_resources` 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python:
-  - 2.7
-  - 3.4
-  - 3.6
+  - 3.12
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: pip install -e .
 # command to run tests, e.g. python setup.py test

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.md
+include pyformance/py.typed

--- a/example_sysmetrics.py
+++ b/example_sysmetrics.py
@@ -5,7 +5,6 @@ import socket
 import time
 import json
 
-import six
 import psutil
 
 from pyformance import global_registry
@@ -21,16 +20,16 @@ class Collector(object):
 
     def collect_disk_io(self, whitelist=[]):
         stats = psutil.disk_io_counters(perdisk=True)
-        for entry, stat in six.iteritems(stats):
+        for entry, stat in stats.items():
             if not whitelist or entry in whitelist:
-                for k, v in six.iteritems(stat._asdict()):
+                for k, v in stat._asdict().items():
                     self.registry.gauge("disk-%s.%s" % (entry, k)).set_value(v)
 
     def collect_network_io(self, whitelist=[]):
         stats = psutil.net_io_counters(pernic=True)
-        for entry, stat in six.iteritems(stats):
+        for entry, stat in stats.items():
             if not whitelist or entry in whitelist:
-                for k, v in six.iteritems(stat._asdict()):
+                for k, v in stat._asdict().items():
                     self.registry.gauge(
                         "nic-%s.%s" % (entry.replace(" ", "_"), k)
                     ).set_value(v)
@@ -39,17 +38,17 @@ class Collector(object):
         stats = psutil.cpu_times(percpu=True)
         for entry, stat in enumerate(stats):
             if not whitelist or entry in whitelist:
-                for k, v in six.iteritems(stat._asdict()):
+                for k, v in stat._asdict().items():
                     self.registry.gauge("cpu%d.%s" % (entry, k)).set_value(v)
 
     def collect_swap_usage(self):
         stats = psutil.swap_memory()
-        for k, v in six.iteritems(stats._asdict()):
+        for k, v in stats._asdict().items():
             self.registry.gauge("swap.%s" % k).set_value(v)
 
     def collect_virtmem_usage(self):
         stats = psutil.virtual_memory()
-        for k, v in six.iteritems(stats._asdict()):
+        for k, v in stats._asdict().items():
             self.registry.gauge("virtmem.%s" % k).set_value(v)
 
     def collect_uptime(self):

--- a/pyformance/__init__.py
+++ b/pyformance/__init__.py
@@ -1,13 +1,39 @@
-__import__("pkg_resources").declare_namespace(__name__)
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
 
-from .registry import MetricsRegistry, global_registry, set_global_registry
-from .registry import timer, counter, meter, histogram, gauge
-from .registry import (
-    dump_metrics,
-    clear,
-    count_calls,
-    meter_calls,
-    hist_calls,
-    time_calls,
-)
-from .meters.timer import call_too_long
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Protocol
+
+
+class Clock(Protocol):
+
+    def time(self) -> float: ...
+
+
+from .registry import MetricsRegistry as MetricsRegistry  # noqa F401
+from .registry import clear as clear  # noqa F401
+from .registry import count_calls as count_calls  # noqa F401
+from .registry import counter as counter  # noqa F401
+from .registry import dump_metrics as dump_metrics  # noqa F401
+from .registry import gauge as gauge  # noqa F401
+from .registry import global_registry as global_registry  # noqa F401
+from .registry import hist_calls as hist_calls  # noqa F401
+from .registry import histogram as histogram  # noqa F401
+from .registry import meter as meter  # noqa F401
+from .registry import meter_calls as meter_calls  # noqa F401
+from .registry import set_global_registry as set_global_registry  # noqa F401
+from .registry import time_calls as time_calls  # noqa F401
+from .registry import timer as timer  # noqa F401

--- a/pyformance/meters/__init__.py
+++ b/pyformance/meters/__init__.py
@@ -1,5 +1,26 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from .counter import Counter
-from .meter import Meter
+from .gauge import CallbackGauge, Gauge, SimpleGauge
 from .histogram import Histogram
+from .meter import Meter
 from .timer import Timer
-from .gauge import Gauge, CallbackGauge, SimpleGauge
+
+__all__ = ["Counter", "CallbackGauge", "Gauge", "SimpleGauge", "Histogram", "Meter", "Timer"]
+
+type any_meter = Histogram | Meter | Gauge[int | float] | Timer | Counter

--- a/pyformance/meters/counter.py
+++ b/pyformance/meters/counter.py
@@ -1,31 +1,47 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from threading import Lock
 
 
 class Counter(object):
-
     """
     An incrementing and decrementing metric
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         super(Counter, self).__init__()
         self.lock = Lock()
         self.counter = 0
 
-    def inc(self, val=1):
+    def inc(self, val: int = 1) -> None:
         "increment counter by val (default is 1)"
         with self.lock:
             self.counter = self.counter + val
 
-    def dec(self, val=1):
+    def dec(self, val: int = 1) -> None:
         "decrement counter by val (default is 1)"
         self.inc(-val)
 
-    def get_count(self):
+    def get_count(self) -> int:
         "return current value of counter"
         return self.counter
 
-    def clear(self):
+    def clear(self) -> None:
         "reset counter to 0"
         with self.lock:
             self.counter = 0

--- a/pyformance/meters/gauge.py
+++ b/pyformance/meters/gauge.py
@@ -1,57 +1,77 @@
-class Gauge(object):
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
 
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from typing import Callable, Union
+
+
+class Gauge[T: Union[int, float]]:
     """
     A base class for reading of a particular.
-    
+
     For example, to instrument a queue depth:
-    
+
     class QueueLengthGaguge(Gauge):
         def __init__(self, queue):
             super(QueueGaguge, self).__init__()
             self.queue = queue
-        
+
         def get_value(self):
             return len(self.queue)
-    
+
     """
 
-    def get_value(self):
+    def get_value(self) -> T:
         "A subclass of Gauge should implement this method"
         raise NotImplementedError()
 
 
-class CallbackGauge(Gauge):
-
+class CallbackGauge[T: Union[int, float]](Gauge[T]):
     """
     A Gauge reading for a given callback
     """
 
-    def __init__(self, callback):
+    def __init__(self, callback: Callable[[], T]) -> None:
         "constructor expects a callable"
         super(CallbackGauge, self).__init__()
         self.callback = callback
 
-    def get_value(self):
+    def get_value(self) -> T:
         "returns the result of callback which is executed each time"
         return self.callback()
 
 
-class SimpleGauge(Gauge):
-
+class SimpleGauge[T: Union[int, float]](Gauge[T]):
     """
     A gauge which holds values with simple getter- and setter-interface
     """
 
-    def __init__(self, value=float("nan")):
+    def __init__(self, value: T) -> None:
         "constructor accepts initial value"
         super(SimpleGauge, self).__init__()
         self._value = value
 
-    def get_value(self):
+    def get_value(self) -> T:
         "getter returns current value"
         return self._value
 
-    def set_value(self, value):
+    def set_value(self, value: T) -> None:
         "setter changes current value"
         # XXX: add locking?
         self._value = value
+
+
+type AnyGauge = Gauge[float | int]

--- a/pyformance/meters/meter.py
+++ b/pyformance/meters/meter.py
@@ -1,22 +1,40 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import time
 from threading import Lock
+
+from .. import Clock
 from ..stats.moving_average import ExpWeightedMovingAvg
 
 
 class Meter(object):
-
     """
     A meter metric which measures mean throughput and one-, five-, and fifteen-minute
     exponentially-weighted moving average throughputs.
     """
 
-    def __init__(self, clock=time):
+    def __init__(self, clock: Clock = time) -> None:
         super(Meter, self).__init__()
         self.lock = Lock()
         self.clock = clock
         self.clear()
 
-    def clear(self):
+    def clear(self) -> None:
         with self.lock:
             self.start_time = self.clock.time()
             self.counter = 0.0
@@ -24,35 +42,32 @@ class Meter(object):
             self.m5rate = ExpWeightedMovingAvg(period=5, clock=self.clock)
             self.m15rate = ExpWeightedMovingAvg(period=15, clock=self.clock)
 
-    def get_one_minute_rate(self):
+    def get_one_minute_rate(self) -> float:
         return self.m1rate.get_rate()
 
-    def get_five_minute_rate(self):
+    def get_five_minute_rate(self) -> float:
         return self.m5rate.get_rate()
 
-    def get_fifteen_minute_rate(self):
+    def get_fifteen_minute_rate(self) -> float:
         return self.m15rate.get_rate()
 
-    def tick(self):
+    def tick(self) -> None:
         self.m1rate.tick()
         self.m5rate.tick()
         self.m15rate.tick()
 
-    def mark(self, value=1):
+    def mark(self, value: float = 1) -> None:
         with self.lock:
             self.counter += value
             self.m1rate.add(value)
             self.m5rate.add(value)
             self.m15rate.add(value)
 
-    def get_count(self):
+    def get_count(self) -> float:
         return self.counter
 
-    def get_mean_rate(self):
+    def get_mean_rate(self) -> float:
         if self.counter == 0:
             return 0
-        elapsed = self.clock.time() - self.start_time
+        elapsed: float = self.clock.time() - self.start_time
         return self.counter / elapsed
-
-    def _convertNsRate(self, ratePerNs):
-        return ratePerNs

--- a/pyformance/registry.py
+++ b/pyformance/registry.py
@@ -1,12 +1,34 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import functools
 import re
 import time
-import sys
-from .meters import Counter, Histogram, Meter, Timer, Gauge, CallbackGauge, SimpleGauge
+from typing import Callable, Mapping, Optional, Union
+
+from . import Clock
+from .meters import CallbackGauge, Counter, Gauge, Histogram, Meter, SimpleGauge, Timer, any_meter
+from .meters.gauge import AnyGauge
+from .meters.timer import TimerSink
+
+type serialized_meter = Mapping[str, str | int | float]
 
 
-class MetricsRegistry(object):
-
+class MetricsRegistry:
     """
     A single interface used to gather metrics on a service. It keeps track of
     all the relevant Counters, Meters, Histograms, and Timers. It does not have
@@ -14,18 +36,18 @@ class MetricsRegistry(object):
     L{MetricsRegistry} to manage all of its metrics tools.
     """
 
-    def __init__(self, clock=time):
+    def __init__(self, clock: Clock = time) -> None:
         """
         Creates a new L{MetricsRegistry} instance.
         """
-        self._timers = {}
-        self._meters = {}
-        self._counters = {}
-        self._histograms = {}
-        self._gauges = {}
+        self._timers: dict[str, Timer] = {}
+        self._meters: dict[str, Meter] = {}
+        self._counters: dict[str, Counter] = {}
+        self._histograms: dict[str, Histogram] = {}
+        self._gauges: dict[str, Gauge[Union[int, float]]] = {}
         self._clock = clock
 
-    def add(self, key, metric):
+    def add(self, key: str, metric: any_meter) -> None:
         """
         Use this method to manually add custom metric instances to the registry
         which are not created with their constructor's default arguments,
@@ -50,7 +72,7 @@ class MetricsRegistry(object):
                 return
         raise TypeError("Invalid class. Could not register metric %r" % key)
 
-    def counter(self, key):
+    def counter(self, key: str) -> Counter:
         """
         Gets a counter based on a key, creates a new one if it does not exist.
 
@@ -63,7 +85,7 @@ class MetricsRegistry(object):
             self._counters[key] = Counter()
         return self._counters[key]
 
-    def histogram(self, key):
+    def histogram(self, key: str) -> Histogram:
         """
         Gets a histogram based on a key, creates a new one if it does not exist.
 
@@ -76,20 +98,23 @@ class MetricsRegistry(object):
             self._histograms[key] = Histogram(clock=self._clock)
         return self._histograms[key]
 
-    def gauge(self, key, gauge=None, default=float("nan")):
+    def gauge[T: float | int](
+        self, key: str, gauge: Gauge[T] | Callable[[], T] | None = None, default: float = float("nan")
+    ) -> AnyGauge:
+        out: AnyGauge
         if key not in self._gauges:
             if gauge is None:
-                gauge = SimpleGauge(
-                    default
-                )  # raise TypeError("gauge required for registering")
+                out = SimpleGauge(default)  # raise TypeError("gauge required for registering")
             elif not isinstance(gauge, Gauge):
                 if not callable(gauge):
                     raise TypeError("gauge getter not callable")
-                gauge = CallbackGauge(gauge)
-            self._gauges[key] = gauge
+                out = CallbackGauge(gauge)
+            else:
+                out = gauge
+            self._gauges[key] = out
         return self._gauges[key]
 
-    def meter(self, key):
+    def meter(self, key: str) -> Meter:
         """
         Gets a meter based on a key, creates a new one if it does not exist.
 
@@ -102,10 +127,10 @@ class MetricsRegistry(object):
             self._meters[key] = Meter(clock=self._clock)
         return self._meters[key]
 
-    def create_sink(self):
+    def create_sink(self) -> TimerSink | None:
         return None
 
-    def timer(self, key):
+    def timer(self, key: str) -> Timer:
         """
         Gets a timer based on a key, creates a new one if it does not exist.
 
@@ -118,26 +143,26 @@ class MetricsRegistry(object):
             self._timers[key] = Timer(clock=self._clock, sink=self.create_sink())
         return self._timers[key]
 
-    def clear(self):
+    def clear(self) -> None:
         self._meters.clear()
         self._counters.clear()
         self._gauges.clear()
         self._timers.clear()
         self._histograms.clear()
 
-    def _get_counter_metrics(self, key):
+    def _get_counter_metrics(self, key: str) -> serialized_meter:
         if key in self._counters:
             counter = self._counters[key]
             return {"count": counter.get_count()}
         return {}
 
-    def _get_gauge_metrics(self, key):
+    def _get_gauge_metrics(self, key: str) -> serialized_meter:
         if key in self._gauges:
             gauge = self._gauges[key]
             return {"value": gauge.get_value()}
         return {}
 
-    def _get_histogram_metrics(self, key):
+    def _get_histogram_metrics(self, key: str) -> serialized_meter:
         if key in self._histograms:
             histogram = self._histograms[key]
             snapshot = histogram.get_snapshot()
@@ -155,7 +180,7 @@ class MetricsRegistry(object):
             return res
         return {}
 
-    def _get_meter_metrics(self, key):
+    def _get_meter_metrics(self, key: str) -> serialized_meter:
         if key in self._meters:
             meter = self._meters[key]
             res = {
@@ -168,7 +193,7 @@ class MetricsRegistry(object):
             return res
         return {}
 
-    def _get_timer_metrics(self, key):
+    def _get_timer_metrics(self, key: str) -> serialized_meter:
         if key in self._timers:
             timer = self._timers[key]
             snapshot = timer.get_snapshot()
@@ -192,7 +217,7 @@ class MetricsRegistry(object):
             return res
         return {}
 
-    def get_metrics(self, key):
+    def get_metrics(self, key: str) -> serialized_meter:
         """
         Gets all the metrics for a specified key.
 
@@ -201,7 +226,8 @@ class MetricsRegistry(object):
 
         :return: C{dict}
         """
-        metrics = {}
+        metrics: dict[str, str | int | float] = {}
+        getter: Callable[[str], serialized_meter]
         for getter in (
             self._get_counter_metrics,
             self._get_histogram_metrics,
@@ -212,13 +238,13 @@ class MetricsRegistry(object):
             metrics.update(getter(key))
         return metrics
 
-    def dump_metrics(self):
+    def dump_metrics(self) -> Mapping[str, serialized_meter]:
         """
         Formats all of the metrics and returns them as a dict.
 
         :return: C{list} of C{dict} of metrics
         """
-        metrics = {}
+        metrics: dict[str, serialized_meter] = {}
         for metric_type in (
             self._counters,
             self._histograms,
@@ -233,8 +259,7 @@ class MetricsRegistry(object):
 
 
 class RegexRegistry(MetricsRegistry):
-
-    """
+    r"""
     A single interface used to gather metrics on a service. This class uses a regex to combine
     measures that match a pattern. For example, if you have a REST API, instead of defining
     a timer for each method, you can use a regex to capture all API calls and group them.
@@ -244,81 +269,81 @@ class RegexRegistry(MetricsRegistry):
         /api/users/2/edit -> users/edit
     """
 
-    def __init__(self, pattern=None, clock=time):
+    def __init__(self, pattern: Optional[str] = None, clock: Clock = time) -> None:
         super(RegexRegistry, self).__init__(clock)
         if pattern is not None:
             self.pattern = re.compile(pattern)
         else:
             self.pattern = re.compile("^$")
 
-    def _get_key(self, key):
+    def _get_key(self, key: str) -> str:
         matches = self.pattern.finditer(key)
         key = "/".join((v for match in matches for v in match.groups() if v))
         return key
 
-    def timer(self, key):
+    def timer(self, key: str) -> Timer:
         return super(RegexRegistry, self).timer(self._get_key(key))
 
-    def histogram(self, key):
+    def histogram(self, key: str) -> Histogram:
         return super(RegexRegistry, self).histogram(self._get_key(key))
 
-    def counter(self, key):
+    def counter(self, key: str) -> Counter:
         return super(RegexRegistry, self).counter(self._get_key(key))
 
-    def gauge(self, key, gauge=None, default=float("nan")):
+    def gauge[T: float | int](
+        self, key: str, gauge: Gauge[T] | Callable[[], T] | None = None, default: float = float("nan")
+    ) -> AnyGauge:
         return super(RegexRegistry, self).gauge(self._get_key(key), gauge, default)
 
-    def meter(self, key):
+    def meter(self, key: str) -> Meter:
         return super(RegexRegistry, self).meter(self._get_key(key))
 
 
 _global_registry = MetricsRegistry()
 
 
-def global_registry():
+def global_registry() -> MetricsRegistry:
     return _global_registry
 
 
-def set_global_registry(registry):
+def set_global_registry(registry: MetricsRegistry) -> None:
     global _global_registry
     _global_registry = registry
 
 
-def counter(key):
+def counter(key: str) -> Counter:
     return _global_registry.counter(key)
 
 
-def histogram(key):
+def histogram(key: str) -> Histogram:
     return _global_registry.histogram(key)
 
 
-def meter(key):
+def meter(key: str) -> Meter:
     return _global_registry.meter(key)
 
 
-def timer(key):
+def timer(key: str) -> Timer:
     return _global_registry.timer(key)
 
 
-def gauge(key, gauge=None):
+def gauge(key: str, gauge: AnyGauge | None = None) -> AnyGauge:
     return _global_registry.gauge(key, gauge)
 
 
-def dump_metrics():
+def dump_metrics() -> Mapping[str, serialized_meter]:
     return _global_registry.dump_metrics()
 
 
-def clear():
+def clear() -> None:
     return _global_registry.clear()
 
 
-def get_qualname(obj):
-    if sys.version_info[0] > 2:
-        return obj.__qualname__
-    return obj.__name__
+def get_qualname[**P, R](obj: Callable[P, R]) -> str:
+    return obj.__qualname__
 
 
-def count_calls(fn):
+def count_calls[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to track the number of times a function is called.
 
@@ -330,14 +355,14 @@ def count_calls(fn):
     """
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         counter("%s_calls" % get_qualname(fn)).inc()
         return fn(*args, **kwargs)
 
     return wrapper
 
 
-def meter_calls(fn):
+def meter_calls[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to the rate at which a function is called.
 
@@ -349,14 +374,14 @@ def meter_calls(fn):
     """
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         meter("%s_calls" % get_qualname(fn)).mark()
         return fn(*args, **kwargs)
 
     return wrapper
 
 
-def hist_calls(fn):
+def hist_calls[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to check the distribution of return values of a function.
 
@@ -368,17 +393,17 @@ def hist_calls(fn):
     """
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         _histogram = histogram("%s_calls" % get_qualname(fn))
         rtn = fn(*args, **kwargs)
-        if type(rtn) in (int, float):
-            _histogram.update(rtn)
+        if isinstance(rtn, (int, float)):
+            _histogram.add(rtn)
         return rtn
 
     return wrapper
 
 
-def time_calls(fn):
+def time_calls[**P, R](fn: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator to time the execution of the function.
 
@@ -390,7 +415,7 @@ def time_calls(fn):
     """
 
     @functools.wraps(fn)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         _timer = timer("%s_calls" % get_qualname(fn))
         with _timer.time(fn=get_qualname(fn)):
             return fn(*args, **kwargs)

--- a/pyformance/reporters/carbon_reporter.py
+++ b/pyformance/reporters/carbon_reporter.py
@@ -4,7 +4,6 @@ import sys
 import struct
 import pickle
 import contextlib
-from six import iteritems
 
 from .reporter import Reporter
 
@@ -54,8 +53,8 @@ class CarbonReporter(Reporter):
                         "%s%s.%s" % (self.prefix, metric_name, metric_key),
                         (timestamp, metric_value),
                     )
-                    for metric_name, metric in iteritems(metrics)
-                    for metric_key, metric_value in iteritems(metric)
+                    for metric_name, metric in metrics.items()
+                    for metric_key, metric_value in metric.items()
                 ],
                 protocol=2,
             )
@@ -63,8 +62,8 @@ class CarbonReporter(Reporter):
             return header + payload
         else:
             metrics_data = []
-            for metric_name, metric in iteritems(metrics):
-                for metric_key, metric_value in iteritems(metric):
+            for metric_name, metric in metrics.items():
+                for metric_key, metric_value in metric.items():
                     metric_line = "%s%s.%s %s %s\n" % (
                         self.prefix,
                         metric_name,

--- a/pyformance/reporters/reporter.py
+++ b/pyformance/reporters/reporter.py
@@ -1,6 +1,5 @@
 import time
 from threading import Thread, Event
-import six
 from ..registry import global_registry, get_qualname
 
 
@@ -47,9 +46,7 @@ class Reporter(object):
                 pass
             next_loop_time += self.reporting_interval
             wait = max(0, next_loop_time - time.time())
-            if six.PY2:
-                time.sleep(wait)
-            elif self._stopped.wait(timeout=wait):
+            if self._stopped.wait(timeout=wait):
                 # wait is faster/better in Python 3
                 # See http://stackoverflow.com/questions/29082268/python-time-sleep-vs-event-wait
                 break  # true if timeout

--- a/pyformance/reporters/syslog_reporter.py
+++ b/pyformance/reporters/syslog_reporter.py
@@ -3,7 +3,6 @@ import sys
 import socket
 import logging
 import logging.handlers
-from six import iteritems
 import json
 
 from .reporter import Reporter
@@ -58,8 +57,8 @@ class SysLogReporter(Reporter):
 
         metrics_data = {"timestamp": timestamp}
         metrics = registry.dump_metrics()
-        for metric_name, metric in iteritems(metrics):
-            for metric_key, metric_value in iteritems(metric):
+        for metric_name, metric in metrics.items():
+            for metric_key, metric_value in metric.items():
                 metrics_data["{}.{}".format(metric_name, metric_key)] = metric_value
         result = json.dumps(metrics_data, sort_keys=True)
         return result

--- a/pyformance/stats/__init__.py
+++ b/pyformance/stats/__init__.py
@@ -1,3 +1,20 @@
-from .samples import ExpDecayingSample
-from .moving_average import ExpWeightedMovingAvg
-from .snapshot import Snapshot
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from .moving_average import ExpWeightedMovingAvg  # noqa F401
+from .samples import ExpDecayingSample  # noqa F401
+from .snapshot import Snapshot  # noqa F401

--- a/pyformance/stats/moving_average.py
+++ b/pyformance/stats/moving_average.py
@@ -1,9 +1,27 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import math
 import time
 
+from pyformance import Clock
+
 
 class ExpWeightedMovingAvg(object):
-
     """
     An exponentially-weighted moving average.
     """
@@ -11,7 +29,7 @@ class ExpWeightedMovingAvg(object):
     INTERVAL = 5.0  # seconds
     SECONDS_PER_MINUTE = 60.0
 
-    def __init__(self, period, interval=INTERVAL, clock=time):
+    def __init__(self, period: int, interval: float = INTERVAL, clock: Clock = time) -> None:
         """
         Create a new EWMA with a specific smoothing constant.
 
@@ -24,21 +42,21 @@ class ExpWeightedMovingAvg(object):
         self.clock = clock
         self.uncounted = 0.0
         self.interval = interval
-        self.rate = -1
+        self.rate: float = -1.0
         self.period = period * ExpWeightedMovingAvg.SECONDS_PER_MINUTE
         self.last_tick = self.clock.time()
 
-    def get_rate(self):
+    def get_rate(self) -> float:
         if self.clock.time() - self.last_tick >= self.interval:
             self.tick()
         if self.rate >= 0:
             return self.rate
         return 0
 
-    def add(self, value):
+    def add(self, value: float) -> None:
         self.uncounted += value
 
-    def tick(self):
+    def tick(self) -> None:
         """
         Mark the passage of time and decay the current rate accordingly.
         """
@@ -58,10 +76,10 @@ class ExpWeightedMovingAvg(object):
 
         self.last_tick = now
 
-    def _alpha(self, interval):
+    def _alpha(self, interval: float) -> float:
         """
         Calculate the alpha based on the time since the last tick. This is
-        necessary because a single threaded Python program loses precision  
+        necessary because a single threaded Python program loses precision
         under high load, so we can't assume a consistant I{EWMA._interval}.
 
         :type interval: C{float}

--- a/pyformance/stats/snapshot.py
+++ b/pyformance/stats/snapshot.py
@@ -1,8 +1,25 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 import math
+from collections.abc import Iterable
 
 
 class Snapshot(object):
-
     """
     This class is used by the histogram meter
     """
@@ -13,43 +30,43 @@ class Snapshot(object):
     P99_Q = 0.99
     P999_Q = 0.999
 
-    def __init__(self, values):
+    def __init__(self, values: Iterable[float]) -> None:
         super(Snapshot, self).__init__()
         self.values = sorted(values)
 
-    def get_size(self):
+    def get_size(self) -> int:
         "get current size"
         return len(self.values)
 
-    def get_sum(self):
+    def get_sum(self) -> float:
         "get current sum"
         return float(sum(self.values))
 
-    def get_max(self):
+    def get_max(self) -> float:
         "get current maximum value"
         if not self.values:
             return 0
         return self.values[-1]
 
-    def get_min(self):
+    def get_min(self) -> float:
         "get current minimum value"
         if not self.values:
             return 0
         return self.values[0]
 
-    def get_mean(self):
+    def get_mean(self) -> float:
         "get current mean value"
         if not self.values:
             return 0
         return float(sum(self.values)) / self.get_size()
 
-    def get_stddev(self):
+    def get_stddev(self) -> float:
         "get current standard deviation"
         if not self.values:
             return 0
         return math.sqrt(self.get_var())
 
-    def get_var(self):
+    def get_var(self) -> float:
         "get current variance"
         if not self.values or self.get_size() == 1:
             return 0
@@ -57,30 +74,30 @@ class Snapshot(object):
         square_differences = [(mean - value) ** 2 for value in self.values]
         return sum(square_differences) / (self.get_size() - 1)
 
-    def get_median(self):
+    def get_median(self) -> float:
         "get current median"
         return self.get_percentile(Snapshot.MEDIAN)
 
-    def get_75th_percentile(self):
+    def get_75th_percentile(self) -> float:
         "get current 75th percentile"
         return self.get_percentile(Snapshot.P75_Q)
 
-    def get_95th_percentile(self):
+    def get_95th_percentile(self) -> float:
         "get current 95th percentile"
         return self.get_percentile(Snapshot.P95_Q)
 
-    def get_99th_percentile(self):
+    def get_99th_percentile(self) -> float:
         "get current 99th percentile"
         return self.get_percentile(Snapshot.P99_Q)
 
-    def get_999th_percentile(self):
+    def get_999th_percentile(self) -> float:
         "get current 999th percentile"
         return self.get_percentile(Snapshot.P999_Q)
 
-    def get_percentile(self, percentile):
+    def get_percentile(self, percentile: float) -> float:
         """
         get custom percentile
-        
+
         :param percentile: float value between 0 and 1
         """
         if percentile < 0 or percentile > 1:

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 import os
 import functools
-import platform
 from setuptools import setup, find_packages
 
 _IN_PACKAGE_DIR = functools.partial(os.path.join, "pyformance")
@@ -8,17 +7,12 @@ _IN_PACKAGE_DIR = functools.partial(os.path.join, "pyformance")
 with open(_IN_PACKAGE_DIR("__version__.py")) as version_file:
     exec(version_file.read())
 
-install_requires = ["six"]  # optional: ["blinker==1.2"]
-if platform.python_version() < "2.7":
-    install_requires.append("unittest2")
-
 setup(
     name="pyformance",
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.11",
     ],
     description="Performance metrics, based on Coda Hale's Yammer metrics",
     license="Apache 2.0",
@@ -27,6 +21,6 @@ setup(
     version=__version__,
     packages=find_packages(),
     data_files=[],
-    install_requires=install_requires,
     scripts=[],
+    python_requires=">=3.12",  # also update classifiers
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
+
+
+class ManualClock(object):
+    def __init__(self):
+        super(ManualClock, self).__init__()
+        self.now = 0
+
+    def add(self, value):
+        self.now = self.now + value
+
+    def time(self):
+        return self.now
+
+
+@pytest.fixture
+def clock():
+    return ManualClock()

--- a/tests/test__carbon_reporter.py
+++ b/tests/test__carbon_reporter.py
@@ -1,4 +1,5 @@
-from six import BytesIO, PY3
+from io import BytesIO
+
 from pyformance import MetricsRegistry
 from pyformance.reporters.carbon_reporter import CarbonReporter
 from tests import TimedTestCase
@@ -82,9 +83,7 @@ class TestCarbonReporter(TimedTestCase):
                 "hist.min 1 2",
                 "hist.95_percentile 512 2",
                 "hist.75_percentile 160.0 2",
-                "hist.std_dev 164.94851048466944 2"
-                if PY3
-                else "hist.std_dev 164.948510485 2",
+                "hist.std_dev 164.94851048466944 2",
                 "hist.max 512 2",
                 "hist.avg 102.3 2",
                 "m1.count 1.0 2",

--- a/tests/test__counter.py
+++ b/tests/test__counter.py
@@ -1,23 +1,38 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import pytest
 from pyformance.meters import Counter
-from tests import TimedTestCase
 
 
-class CounterTestCase(TimedTestCase):
-    def setUp(self):
-        super(CounterTestCase, self).setUp()
-        self.counter = Counter()
+@pytest.fixture
+def counter():
+    return Counter()
 
-    def tearDown(self):
-        super(CounterTestCase, self).tearDown()
 
-    def test__inc(self):
-        before = self.counter.get_count()
-        self.counter.inc()
-        after = self.counter.get_count()
-        self.assertEqual(before + 1, after)
+def test__inc(counter):
+    before = counter.get_count()
+    counter.inc()
+    after = counter.get_count()
+    assert before + 1 == after
 
-    def test__dec(self):
-        before = self.counter.get_count()
-        self.counter.dec()
-        after = self.counter.get_count()
-        self.assertEqual(before - 1, after)
+
+def test__dec(counter):
+    before = counter.get_count()
+    counter.dec()
+    after = counter.get_count()
+    assert before - 1 == after

--- a/tests/test__gauge.py
+++ b/tests/test__gauge.py
@@ -1,19 +1,28 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from pyformance.meters import CallbackGauge
-from tests import TimedTestCase
 
 
-class CallbackGaugeTestCase(TimedTestCase):
-    def setUp(self):
-        super(CallbackGaugeTestCase, self).setUp()
-        self._value = None
-        self.gauge = CallbackGauge(self._get_val)
+def test_gauge():
+    value = 123
 
-    def tearDown(self):
-        super(CallbackGaugeTestCase, self).tearDown()
+    def test_callback() -> int:
+        return value
 
-    def _get_val(self):
-        return self._value
-
-    def test__value(self):
-        self._value = 123
-        self.assertEqual(self.gauge.get_value(), self._value)
+    gauge = CallbackGauge(test_callback)
+    assert gauge.get_value() == 123

--- a/tests/test__histogram.py
+++ b/tests/test__histogram.py
@@ -1,64 +1,82 @@
-from tests import TimedTestCase
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from pyformance.meters import Histogram
+from pytest import approx
 
 
-class HistogramTestCase(TimedTestCase):
-    def test__a_sample_of_100_from_1000(self):
-        hist = Histogram(100, 0.99)
-        for i in range(1000):
-            hist.add(i)
+def test__a_sample_of_100_from_1000():
+    hist = Histogram(100, 0.99)
+    for i in range(1000):
+        hist.add(i)
 
-        self.assertEqual(1000, hist.get_count())
-        self.assertEqual(100, hist.sample.get_size())
-        snapshot = hist.get_snapshot()
-        self.assertEqual(100, snapshot.get_size())
+    assert 1000 == hist.get_count()
+    assert 100 == hist.sample.get_size()
+    snapshot = hist.get_snapshot()
+    assert 100 == snapshot.get_size()
 
-        for i in snapshot.values:
-            self.assertTrue(0 <= i and i <= 1000)
+    for i in snapshot.values:
+        assert 0 <= i and i <= 1000
 
-        self.assertEqual(999, hist.get_max())
-        self.assertEqual(0, hist.get_min())
-        self.assertEqual(499.5, hist.get_mean())
-        self.assertAlmostEqual(83416.6666, hist.get_var(), delta=0.0001)
+    assert 999 == hist.get_max()
+    assert 0 == hist.get_min()
+    assert 499.5 == hist.get_mean()
+    assert 83416.6666 == approx(hist.get_var(), 0.0001)
 
-    def test__a_sample_of_100_from_10(self):
-        hist = Histogram(100, 0.99)
-        for i in range(10):
-            hist.add(i)
 
-        self.assertEqual(10, hist.get_count())
-        self.assertEqual(10, hist.sample.get_size())
-        snapshot = hist.get_snapshot()
-        self.assertEqual(10, snapshot.get_size())
+def test__a_sample_of_100_from_10():
+    hist = Histogram(100, 0.99)
+    for i in range(10):
+        hist.add(i)
 
-        for i in snapshot.values:
-            self.assertTrue(0 <= i and i <= 10)
+    assert 10 == hist.get_count()
+    assert 10 == hist.sample.get_size()
+    snapshot = hist.get_snapshot()
+    assert 10 == snapshot.get_size()
 
-        self.assertEqual(9, hist.get_max())
-        self.assertEqual(0, hist.get_min())
-        self.assertEqual(4.5, hist.get_mean())
-        self.assertAlmostEqual(9.1666, hist.get_var(), delta=0.0001)
+    for i in snapshot.values:
+        assert 0 <= i and i <= 10
 
-    def test__a_long_wait_should_not_corrupt_sample(self):
-        hist = Histogram(10, 0.015, clock=self.clock)
+    assert 9 == hist.get_max()
+    assert 0 == hist.get_min()
+    assert 4.5 == hist.get_mean()
+    assert 9.1666 == approx(hist.get_var(), 0.0001)
 
-        for i in range(1000):
-            hist.add(1000 + i)
-            self.clock.add(0.1)
 
-        self.assertEqual(hist.get_snapshot().get_size(), 10)
-        for i in hist.sample.get_snapshot().values:
-            self.assertTrue(1000 <= i and i <= 2000)
+def test__a_long_wait_should_not_corrupt_sample(clock):
+    hist = Histogram(10, 0.015, clock=clock)
 
-        self.clock.add(15 * 3600)  # 15 hours, should trigger rescale
-        hist.add(2000)
-        self.assertEqual(hist.get_snapshot().get_size(), 2)
-        for i in hist.sample.get_snapshot().values:
-            self.assertTrue(1000 <= i and i <= 3000)
+    for i in range(1000):
+        hist.add(1000 + i)
+        clock.add(0.1)
 
-        for i in range(1000):
-            hist.add(3000 + i)
-            self.clock.add(0.1)
-        self.assertEqual(hist.get_snapshot().get_size(), 10)
-        for i in hist.sample.get_snapshot().values:
-            self.assertTrue(3000 <= i and i <= 4000)
+    assert hist.get_snapshot().get_size() == 10
+    for i in hist.sample.get_snapshot().values:
+        assert 1000 <= i and i <= 2000
+
+    clock.add(15 * 3600)  # 15 hours, should trigger rescale
+    hist.add(2000)
+    assert hist.get_snapshot().get_size() == 2
+    for i in hist.sample.get_snapshot().values:
+        assert 1000 <= i and i <= 3000
+
+    for i in range(1000):
+        hist.add(3000 + i)
+        clock.add(0.1)
+    assert hist.get_snapshot().get_size() == 10
+    for i in hist.sample.get_snapshot().values:
+        assert 3000 <= i and i <= 4000

--- a/tests/test__meter.py
+++ b/tests/test__meter.py
@@ -1,80 +1,85 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from pyformance.meters import Meter
-from tests import TimedTestCase
+from pytest import approx
 
 
-class MeterTestCase(TimedTestCase):
-    def setUp(self):
-        super(MeterTestCase, self).setUp()
-        self.meter = Meter(TimedTestCase.clock)
+def test__one_minute_rate(clock):
+    meter = Meter(clock)
+    meter.mark(3)
+    clock.add(5)
+    meter.tick()
 
-    def tearDown(self):
-        super(MeterTestCase, self).tearDown()
+    # the EWMA has a rate of 0.6 events/sec after the first tick
+    assert 0.6 == approx(meter.get_one_minute_rate(), 0.000001)
 
-    def test__one_minute_rate(self):
-        self.meter.mark(3)
-        self.clock.add(5)
-        self.meter.tick()
+    clock.add(60)
+    # the EWMA has a rate of 0.22072766 events/sec after 1 minute
+    assert 0.22072766 == approx(meter.get_one_minute_rate(), 0.000001)
 
-        # the EWMA has a rate of 0.6 events/sec after the first tick
-        self.assertAlmostEqual(0.6, self.meter.get_one_minute_rate(), delta=0.000001)
+    clock.add(60)
+    # the EWMA has a rate of 0.08120117 events/sec after 2 minute
+    assert 0.08120117 == approx(meter.get_one_minute_rate(), 0.000001)
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.22072766 events/sec after 1 minute
-        self.assertAlmostEqual(
-            0.22072766, self.meter.get_one_minute_rate(), delta=0.000001
-        )
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.08120117 events/sec after 2 minute
-        self.assertAlmostEqual(
-            0.08120117, self.meter.get_one_minute_rate(), delta=0.000001
-        )
+def test__five_minute_rate(clock):
+    meter = Meter(clock)
 
-    def test__five_minute_rate(self):
-        self.meter.mark(3)
-        self.clock.add(5)
-        self.meter.tick()
+    meter.mark(3)
+    clock.add(5)
+    meter.tick()
 
-        # the EWMA has a rate of 0.6 events/sec after the first tick
-        self.assertAlmostEqual(0.6, self.meter.get_five_minute_rate(), delta=0.000001)
+    # the EWMA has a rate of 0.6 events/sec after the first tick
+    assert 0.6 == approx(meter.get_five_minute_rate(), 0.000001)
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.49123845 events/sec after 1 minute
-        self.assertAlmostEqual(
-            0.49123845, self.meter.get_five_minute_rate(), delta=0.000001
-        )
+    clock.add(60)
+    # the EWMA has a rate of 0.49123845 events/sec after 1 minute
+    assert 0.49123845 == approx(meter.get_five_minute_rate(), 0.000001)
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.40219203 events/sec after 2 minute
-        self.assertAlmostEqual(
-            0.40219203, self.meter.get_five_minute_rate(), delta=0.000001
-        )
+    clock.add(60)
+    # the EWMA has a rate of 0.40219203 events/sec after 2 minute
+    assert 0.40219203 == approx(meter.get_five_minute_rate(), 0.000001)
 
-    def test__fifteen_minute_rate(self):
-        self.meter.mark(3)
-        self.clock.add(5)
-        self.meter.tick()
 
-        # the EWMA has a rate of 0.6 events/sec after the first tick
-        self.assertAlmostEqual(
-            0.6, self.meter.get_fifteen_minute_rate(), delta=0.000001
-        )
+def test__fifteen_minute_rate(clock):
+    meter = Meter(clock)
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.56130419 events/sec after 1 minute
-        self.assertAlmostEqual(
-            0.56130419, self.meter.get_fifteen_minute_rate(), delta=0.000001
-        )
+    meter.mark(3)
+    clock.add(5)
+    meter.tick()
 
-        self.clock.add(60)
-        # the EWMA has a rate of 0.52510399 events/sec after 2 minute
-        self.assertAlmostEqual(
-            0.52510399, self.meter.get_fifteen_minute_rate(), delta=0.000001
-        )
+    # the EWMA has a rate of 0.6 events/sec after the first tick
+    assert 0.6 == approx(meter.get_fifteen_minute_rate(), 0.000001)
 
-    def test__mean_rate(self):
-        self.meter.mark(60)
-        self.clock.add(60)
-        self.meter.tick()
-        val = self.meter.get_mean_rate()
-        self.assertEqual(1, val)
+    clock.add(60)
+    # the EWMA has a rate of 0.56130419 events/sec after 1 minute
+    assert 0.56130419 == approx(meter.get_fifteen_minute_rate(), 0.000001)
+
+    clock.add(60)
+    # the EWMA has a rate of 0.52510399 events/sec after 2 minute
+    assert 0.52510399 == approx(meter.get_fifteen_minute_rate(), 0.000001)
+
+
+def test__mean_rate(clock):
+    meter = Meter(clock)
+
+    meter.mark(60)
+    clock.add(60)
+    meter.tick()
+    val = meter.get_mean_rate()
+    assert 1 == val

--- a/tests/test__moving_average.py
+++ b/tests/test__moving_average.py
@@ -1,135 +1,156 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from pyformance.stats.moving_average import ExpWeightedMovingAvg
-from tests import TimedTestCase
+from pytest import approx
 
 
-class EWMATests(TimedTestCase):
-    def test_one_minute_EWMA_five_sec_tick(self):
-        self.ewma = ExpWeightedMovingAvg(1, clock=self.clock)
+def test_one_minute_EWMA_five_sec_tick(clock):
+    ewma = ExpWeightedMovingAvg(1, clock=clock)
 
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
 
-        for expected_rate in [
-            0.6,
-            0.22072766,
-            0.08120117,
-            0.02987224,
-            0.01098938,
-            0.00404277,
-            0.00148725,
-            0.00054713,
-            0.00020128,
-            0.00007405,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+    for expected_rate in [
+        0.6,
+        0.22072766,
+        0.08120117,
+        0.02987224,
+        0.01098938,
+        0.00404277,
+        0.00148725,
+        0.00054713,
+        0.00020128,
+        0.00007405,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate, 0.0001)
+        clock.add(60)
 
-    def test_five_minute_EWMA_five_sec_tick(self):
-        self.ewma = ExpWeightedMovingAvg(5, clock=self.clock)
 
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
+def test_five_minute_EWMA_five_sec_tick(clock):
+    ewma = ExpWeightedMovingAvg(5, clock=clock)
 
-        for expected_rate in [
-            0.6,
-            0.49123845,
-            0.40219203,
-            0.32928698,
-            0.26959738,
-            0.22072766,
-            0.18071653,
-            0.14795818,
-            0.12113791,
-            0.09917933,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
 
-    def test_fifteen_minute_EWMA_five_sec_tick(self):
-        self.ewma = ExpWeightedMovingAvg(15, clock=self.clock)
+    for expected_rate in [
+        0.6,
+        0.49123845,
+        0.40219203,
+        0.32928698,
+        0.26959738,
+        0.22072766,
+        0.18071653,
+        0.14795818,
+        0.12113791,
+        0.09917933,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate)
+        clock.add(60)
 
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
 
-        for expected_rate in [
-            0.6,
-            0.56130419,
-            0.52510399,
-            0.49123845,
-            0.45955700,
-            0.42991879,
-            0.40219203,
-            0.37625345,
-            0.35198773,
-            0.32928698,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+def test_fifteen_minute_EWMA_five_sec_tick(clock):
+    ewma = ExpWeightedMovingAvg(15, clock=clock)
 
-    def test_one_minute_EWMA_one_minute_tick(self):
-        self.ewma = ExpWeightedMovingAvg(1, 60, clock=self.clock)
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
 
-        for expected_rate in [
-            0.6,
-            0.22072766,
-            0.08120117,
-            0.02987224,
-            0.01098938,
-            0.00404277,
-            0.00148725,
-            0.00054713,
-            0.00020128,
-            0.00007405,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+    for expected_rate in [
+        0.6,
+        0.56130419,
+        0.52510399,
+        0.49123845,
+        0.45955700,
+        0.42991879,
+        0.40219203,
+        0.37625345,
+        0.35198773,
+        0.32928698,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate)
+        clock.add(60)
 
-    def test_five_minute_EWMA_one_minute_tick(self):
-        self.ewma = ExpWeightedMovingAvg(5, 60, clock=self.clock)
 
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
+def test_one_minute_EWMA_one_minute_tick(clock):
+    ewma = ExpWeightedMovingAvg(1, 60, clock=clock)
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
 
-        for expected_rate in [
-            0.6,
-            0.49123845,
-            0.40219203,
-            0.32928698,
-            0.26959738,
-            0.22072766,
-            0.18071653,
-            0.14795818,
-            0.12113791,
-            0.09917933,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+    for expected_rate in [
+        0.6,
+        0.22072766,
+        0.08120117,
+        0.02987224,
+        0.01098938,
+        0.00404277,
+        0.00148725,
+        0.00054713,
+        0.00020128,
+        0.00007405,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate, 0.0001)
+        clock.add(60)
 
-    def test_fifteen_minute_EWMA_one_minute_tick(self):
-        self.ewma = ExpWeightedMovingAvg(15, 60, clock=self.clock)
 
-        self.ewma.add(3)
-        self.clock.add(5)
-        self.ewma.tick()
+def test_five_minute_EWMA_one_minute_tick(clock):
+    ewma = ExpWeightedMovingAvg(5, 60, clock=clock)
 
-        for expected_rate in [
-            0.6,
-            0.56130419,
-            0.52510399,
-            0.49123845,
-            0.45955700,
-            0.42991879,
-            0.40219203,
-            0.37625345,
-            0.35198773,
-            0.32928698,
-        ]:
-            self.assertAlmostEqual(self.ewma.get_rate(), expected_rate)
-            self.clock.add(60)
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
+
+    for expected_rate in [
+        0.6,
+        0.49123845,
+        0.40219203,
+        0.32928698,
+        0.26959738,
+        0.22072766,
+        0.18071653,
+        0.14795818,
+        0.12113791,
+        0.09917933,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate)
+        clock.add(60)
+
+
+def test_fifteen_minute_EWMA_one_minute_tick(clock):
+    ewma = ExpWeightedMovingAvg(15, 60, clock=clock)
+
+    ewma.add(3)
+    clock.add(5)
+    ewma.tick()
+
+    for expected_rate in [
+        0.6,
+        0.56130419,
+        0.52510399,
+        0.49123845,
+        0.45955700,
+        0.42991879,
+        0.40219203,
+        0.37625345,
+        0.35198773,
+        0.32928698,
+    ]:
+        assert ewma.get_rate() == approx(expected_rate)
+        clock.add(60)

--- a/tests/test__timer.py
+++ b/tests/test__timer.py
@@ -1,22 +1,61 @@
+"""
+Copyright 2014 Omer Gertel
+Copyright 2025 Inmanta
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
 from pyformance.meters import Timer
-from tests import TimedTestCase
 
 
-class TimerTestCase(TimedTestCase):
-    def setUp(self):
-        super(TimerTestCase, self).setUp()
-        self.timer = Timer()
+def test__start_stop_clear(clock):
+    timer = Timer(clock=clock)
 
-    def tearDown(self):
-        super(TimerTestCase, self).tearDown()
+    context = timer.time()
+    clock.add(1)
+    context.stop()
 
-    def test__start_stop_clear(self):
-        context = self.timer.time()
-        self.clock.add(1)
-        context.stop()
+    assert timer.get_count() == 1
+    assert timer.get_max() == 1
+    assert timer.get_min() == 1
+    assert timer.get_mean() == 1
+    assert timer.get_sum() == 1
+    assert timer.get_mean_rate() == 1
 
-        self.assertEqual(self.timer.get_count(), 1)
+    context = timer.time()
+    clock.add(2)
+    context.stop()
 
-        self.timer.clear()
+    assert timer.get_count() == 2
+    assert timer.get_max() == 2
+    assert timer.get_min() == 1
+    assert timer.get_mean() == 1.5
+    assert timer.get_snapshot().get_median() == 1.5
+    assert timer.get_sum() == 3
+    assert timer.get_mean_rate() == 2.0 / 3
 
-        self.assertEqual(self.timer.get_count(), 0)
+    context = timer.time()
+    clock.add(1)
+    context.stop()
+
+    assert timer.get_count() == 3
+    assert timer.get_max() == 2
+    assert timer.get_min() == 1
+    assert timer.get_mean() == 4.0 / 3
+    assert timer.get_snapshot().get_median() == 1
+    assert timer.get_sum() == 4
+    assert timer.get_mean_rate() == 0.75
+
+    timer.clear()
+
+    assert timer.get_count() == 0

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py34,py35,py36
+envlist = py312
 
 [testenv]
 commands=


### PR DESCRIPTION
Hi,

Thank you for building this very useful library. 

Because pkg_resources is deprecated and removed in Python 3.12, we needed an update of the library. 
We have implemented this at https://github.com/inmanta/inmanta-core/pull/9246.

This PR backports our changes:

1. Remove pkg_resources
2. Add mypy types
3. Move testing to native pytest
4. Drop support for python versions <3.12 

I hope this can get merged and released.

Wouter